### PR TITLE
Add minimal PHILOVOID webapp

### DIFF
--- a/webapp/index.html
+++ b/webapp/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>PHILOVOID</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="app-header">
+    <h1>PHILOVOID</h1>
+  </header>
+  <main id="chat" class="chat"></main>
+  <form id="message-form" class="input-form">
+    <input id="message-input" type="text" placeholder="Converse with the void..." autocomplete="off" />
+    <button type="submit">Send</button>
+  </form>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/webapp/main.js
+++ b/webapp/main.js
@@ -1,0 +1,25 @@
+// Simple chat logic for PHILOVOID webapp
+const form = document.getElementById('message-form');
+const input = document.getElementById('message-input');
+const chat = document.getElementById('chat');
+
+function addMessage(text, role) {
+  const div = document.createElement('div');
+  div.className = `message ${role}`;
+  div.textContent = text;
+  chat.appendChild(div);
+  chat.scrollTop = chat.scrollHeight;
+}
+
+form.addEventListener('submit', (e) => {
+  e.preventDefault();
+  const text = input.value.trim();
+  if (!text) return;
+  addMessage(text, 'user');
+  input.value = '';
+
+  // Placeholder assistant response
+  setTimeout(() => {
+    addMessage('Error: Could not reach the philosophical void. The connection to deeper understanding has been severed.', 'assistant');
+  }, 500);
+});

--- a/webapp/styles.css
+++ b/webapp/styles.css
@@ -1,0 +1,56 @@
+/* Basic styling for the PHILOVOID webapp */
+body {
+  background-color: #0A0A0C;
+  color: #c8c8d0;
+  font-family: "EB Garamond", serif;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+.app-header {
+  text-align: center;
+  padding: 1rem;
+  border-bottom: 1px solid #2a2a30;
+}
+
+.chat {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1rem;
+}
+
+.message {
+  margin-bottom: 1rem;
+}
+
+.message.user {
+  text-align: right;
+}
+
+.input-form {
+  display: flex;
+  border-top: 1px solid #2a2a30;
+}
+
+.input-form input {
+  flex: 1;
+  padding: 0.75rem;
+  border: none;
+  background: #121214;
+  color: #c8c8d0;
+}
+
+.input-form button {
+  padding: 0 1rem;
+  background: #7b61ff;
+  border: none;
+  color: white;
+  cursor: pointer;
+}
+
+.input-form button:disabled {
+  background: #5a48b9;
+  cursor: not-allowed;
+}


### PR DESCRIPTION
## Summary
- Introduce a standalone PHILOVOID web interface with basic chat layout and input handling.
- Style the interface with a dark theme consistent with existing design elements.
- Implement simple client-side message flow using placeholder assistant responses.

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c2fc9172e48331aca73e6b1732463e